### PR TITLE
Remove secrets expression from action metadata file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,10 +13,10 @@ inputs:
     required: true
     default: 'kong'
   github_token:
-    description: 'Just set as ${{ secrets.GITHUB_TOKEN }} here.'
+    description: 'Just set as secrets.GITHUB_TOKEN here.'
     required: true
   options:
-    description: 'decK option arguments: e.g. --kong-addr ${{ secrets.KONG_ADDR }} --headers ${{ secrets.KONG_HEADERS }} when needed. Make sure you set the secrets in your repo settings.'
+    description: 'decK option arguments: e.g. --kong-addr secrets.KONG_ADDR --headers secrets.KONG_HEADERS when needed. Make sure you set the secrets in your repo settings.'
     required: false
 runs:
   using: 'docker'


### PR DESCRIPTION
It seems that an action metadata file cannot contain an expression accessing secrets. When consuming this action from an external location, Github failed to load the action because of these. When I removed them, Github successfully loaded the action. 🎉 

![image](https://user-images.githubusercontent.com/4312346/92038074-edf84600-edc6-11ea-9cad-0bf3a9dca091.png)

![image](https://user-images.githubusercontent.com/4312346/92038214-2861e300-edc7-11ea-82fb-c62d7eed2138.png)
